### PR TITLE
collect_image improvements

### DIFF
--- a/blurple.py
+++ b/blurple.py
@@ -39,8 +39,6 @@ MAX_FILE_SIZE = 8 * 1024 * 1024 * 16  # 16M
 
 COLOUR_BUFFER = 20
 
-MENTION_RE = re.compile(r'<@!?([0-9]+)>')
-
 bot.remove_command('help')
 
 allowed_users_list = set([int(i) for i in os.environ.get('ALLOWED_USERS').split(',')])
@@ -210,19 +208,7 @@ async def timeit(ctx, *, command: str):
     await ctx.send(f'**{BOT_PREFIX}{new_ctx.command.qualified_name}** took **{end - start:.2f}s** to run')
 
 
-async def collect_image(ctx, hint, static=False):
-    mentions = MENTION_RE.findall(hint) if hint is not None else []
-
-    if mentions:
-        user = await bot.get_user_info(int(mentions[0]))
-        url = user.avatar_url
-    elif hint:
-        url = hint
-    elif ctx.message.attachments:
-        url = ctx.message.attachments[0].url
-    else:
-        url = ctx.author.avatar_url
-
+async def collect_image(hint, static=False):
     data = io.BytesIO()
     length = 0
     async with aiohttp.ClientSession() as cs:
@@ -324,7 +310,21 @@ async def blurple(ctx, arg1=None):
 @bot.command(aliases=['blurplfy', 'blurplefier', 'blurplfygif', 'blurplefiergif', 'blurplefygif'])
 @commands.cooldown(rate=1, per=180, type=BucketType.user)
 async def blurplefy(ctx, arg1=None):
-    frames, url = await collect_image(ctx, arg1)
+    if ctx.message.attachments:
+        url = ctx.message.attachments[0].url
+    else:
+        if not arg1:
+            url = ctx.author.avatar_url
+        else:
+            try:
+                member = await commands.MemberConverter().convert(ctx, arg1)
+                url = member.avatar_url
+            except commands.BadArgument:
+                url = arg1
+    try:
+        frames, url = await collect_image(url)
+    except ValueError:
+        return await ctx.send("This does not appear to be a valid URL nor member.")
     if frames is None:
         return await ctx.message.add_reaction('\N{CROSS MARK}')
 

--- a/blurple.py
+++ b/blurple.py
@@ -324,7 +324,7 @@ async def blurplefy(ctx, arg1=None):
     try:
         frames, url = await collect_image(url)
     except ValueError:
-        return await ctx.send("This does not appear to be a valid URL nor member.")
+        return await ctx.message.add_reaction('\N{CROSS MARK}')
     if frames is None:
         return await ctx.message.add_reaction('\N{CROSS MARK}')
 


### PR DESCRIPTION
This PR removes the reliance on the hardcoded regex and instead leaves it to the MemberConverter in the discord.py library to search for members.

This allows for:
* Potential savings of one API call
* blurplefy command will now accept nicknames or usernames (case-sensitive) without needing to mention the user